### PR TITLE
解决第三方依赖包不存在的问题

### DIFF
--- a/db-redis-hash.go
+++ b/db-redis-hash.go
@@ -1,8 +1,9 @@
 package Figo
 
 import (
+	"errors"
+
 	"github.com/garyburd/redigo/redis"
-	"github.com/murlokswarm/errors"
 )
 
 type RedisHash struct {


### PR DESCRIPTION
github.com/murlokswarm/errors package 已经被作者删除